### PR TITLE
Remove module display_intf_headers

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -33,18 +33,6 @@ cc_library_headers {
     export_header_lib_headers: ["libhardware_headers"],
 }
 
-cc_library_headers {
-    name: "display_intf_headers",
-    vendor_available: true,
-    export_include_dirs: [
-        "include",
-        "libqdutils",
-        "gralloc",
-    ],
-    header_libs: ["libhardware_headers"],
-    export_header_lib_headers: ["libhardware_headers"],
-}
-
 subdirs = [
     "libqservice",
     "libqdutils",


### PR DESCRIPTION
The module is already defined in https://github.com/Wave-Project/vendor_qcom_opensource_commonsys-intf_display/blob/p/Android.bp